### PR TITLE
Add TargetFrameworkMonikerAssemblyAttributesPath to EmbeddedFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ a `Directory.Build.targets` file with the following:
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+    <EmbeddedFiles Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
We were debugging source link with @atifaziz here: https://github.com/atifaziz/Hazz/pull/13

We established that the `TargetFrameworkMonikerAssemblyAttributesPath` generated file also needs to be added to `@(EmbeddedFiles)`