### PR TITLE
Update local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ a `Directory.Build.targets` file with the following:
 
  
 ## Building locally
-To see/test this locally, build with `dotnet build /p:TF_BUILD=true`. If you examine the resulting package in [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer),
+To see/test this locally, build with `dotnet build -p:TF_BUILD=true` (or `dotnet build -p:GITHUB_ACTIONS=true`, depending on your CI). If you examine the resulting package in [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer),
 it will pass.


### PR DESCRIPTION
- https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build#msbuild states options should use a dash rather than a slash
- Provide the reader with an example for using GitHub as a CI