### PR TITLE
Added instructions for CI running on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ For GitHub Actions, the variable is `GITHUB_ACTIONS`, so the result would be:
 </PropertyGroup>
 ```
 
+For GitHub Actions, the variable is `TEAMCITY_VERSION`, so the result would be:
+
+<PropertyGroup Condition="'$(TEAMCITY_VERSION)' != ''">
+  <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+</PropertyGroup>
+
 Or another option is to pass it to `msbuild` or `dotnet` with `/p:ContinuousIntegrationBuild=true`
 
 Also  `EmbedUntrackedSources` should be enabled so that compiler-generated source, like AssemblyInfo, are included


### PR DESCRIPTION
Hi Claire,
not sure if you are accepting PRs here to expand it, but in case you are, here is a quick one to add instructions for TeamCity, given its popularity in the .NET ecosystem.

Thank you,
 Alessio